### PR TITLE
Ember v1.12.0 Support

### DIFF
--- a/addon/stained-by-children.js
+++ b/addon/stained-by-children.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
 
+
   isFilthy: Ember.computed('areChildrenDirty', 'currentState.isDirty', function() {
     return this.get('currentState.isDirty') || this.get('areChildrenDirty');
   }),
@@ -17,8 +18,16 @@ export default Ember.Mixin.create({
     // Setting the `areChildrenDirty` property dynamically.
     // This is required in order to bind it to all relationships.
     this._defineAreChildrenDirty();
+    this._deprecatedDefineIsDirty();
   },
 
+  _deprecatedDefineIsDirty: function() {
+    Ember.defineProperty(this, 'isDirty', Ember.computed('areChildrenDirty', 'currentState.isDirty', function() {
+      return this.get('currentState.isDirty') || this.get('areChildrenDirty');
+    }));
+
+    Ember.deprecate('ember-cli-stained-by-children: redifining the \'isDirty\' property is no longer allowed in Ember and will be removed in a future version of ember-cli-stained-by-children. Please use \'isFilthy\' instead.', false);
+  },
 
   _defineAreChildrenDirty: function() {
     var
@@ -60,9 +69,9 @@ export default Ember.Mixin.create({
   _propertyNameForRelationship: function(relationshipName, relationship) {
     var propertyName = relationshipName;
     if (relationship.kind === 'hasMany') {
-      propertyName += ".@each.isDirty";
+      propertyName += ".@each.{isDirty,isFilthy}";
     } else {
-      propertyName += ".isDirty";
+      propertyName += ".{isDirty,isFilthy}";
     }
     return propertyName;
   },
@@ -108,11 +117,11 @@ export default Ember.Mixin.create({
 
     if (relationship.kind === 'hasMany') {
       return child.any(function (item) {
-        return item.get('isDirty');
+        return item.get('isFilthy') || item.get('isDirty');
       });
 
     } else {
-      return child.get('isDirty');
+      return child.get('isFilthy') || child.get('isDirty');
     }
   }
 });

--- a/addon/stained-by-children.js
+++ b/addon/stained-by-children.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
 
-  isDirty: Ember.computed('areChildrenDirty', 'currentState.isDirty', function() {
+  isFilthy: Ember.computed('areChildrenDirty', 'currentState.isDirty', function() {
     return this.get('currentState.isDirty') || this.get('areChildrenDirty');
   }),
 

--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "ember-cli-stained-by-children",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
+    "ember": "canary",
+    "ember-data": "canary",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
@@ -13,5 +13,8 @@
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
     "es5-shim": "^4.0.5"
+  },
+  "resolutions": {
+    "ember": "canary"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "ember-cli-stained-by-children",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "canary",
-    "ember-data": "canary",
+    "ember": "1.10.0",
+    "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
@@ -13,8 +13,5 @@
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
     "es5-shim": "^4.0.5"
-  },
-  "resolutions": {
-    "ember": "canary"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-stained-by-children",
-  "version": "v0.4.0-ember1.12.0-workaround",
+  "version": "v0.4.0",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "git://github.com/jmurphyau/ember-cli-stained-by-children.git#v0.4.0-ember1.12.0-workaround",
+  "repository": "git://github.com/lolmaus/ember-cli-stained-by-children",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-stained-by-children",
-  "version": "0.4.0",
+  "version": "v0.4.0-ember1.12.0-support",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": "git://github.com/jmurphyau/ember-cli-stained-by-children.git#v0.4.0-ember1.12.0-support",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-stained-by-children",
-  "version": "v0.4.0-ember1.12.0-support",
+  "version": "v0.4.0-ember1.12.0-workaround",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "git://github.com/jmurphyau/ember-cli-stained-by-children.git#v0.4.0-ember1.12.0-support",
+  "repository": "git://github.com/jmurphyau/ember-cli-stained-by-children.git#v0.4.0-ember1.12.0-workaround",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
In Ember v1.12.0 you can no longer redefine `isDirty` directly so a new field `isFilty` has been created.

The `isDirty` field can still be defined using `Ember.defineProperty` so for backwards compat. this has been done with a deprecation warning added.

As a temporary workaround for anyone viewing this pull request - I've implemented a 'v0.4.0-ember1.12.0-workaround' tag on my fork which can be used to resolve the issues when using the canary branch. 

To use this you can change your package.json file from:

`"ember-cli-stained-by-children": "0.4.0"`

to:

`"ember-cli-stained-by-children": "git://github.com/jmurphyau/ember-cli-stained-by-children.git#v0.4.0-ember1.12.0-workaround"`
