### PR TITLE
Fix for clean-embedded-children in Ember Data 1.0.0-beta.19.2

### DIFF
--- a/addon/clean-embedded-children.js
+++ b/addon/clean-embedded-children.js
@@ -28,6 +28,14 @@ export default Ember.Mixin.create({
     );
   },
 
+  _clearChildAttributes: function(child) {
+    if(child.get('_internalModel')) {
+      // Ember Data 1.0.0-beta.19.2 uses _internalModel
+      child.set('_internalModel._attributes', {});
+    } else {
+      child.set('_attributes', {});
+    }
+  },
 
   save: function() {
     return this
@@ -35,8 +43,8 @@ export default Ember.Mixin.create({
       .then(
         function() {
           this._processChildren(function(child) {
-            child.set('_attributes', {});
-          });
+            this._clearChildAttributes(child);
+          }.bind(this));
         }.bind(this)
     );
   },
@@ -69,8 +77,8 @@ export default Ember.Mixin.create({
 
   _cleanChildren: function() {
     this._processChildren(function(child) {
-      child.set('_attributes', {});
-    });
+      this._clearChildAttributes(child);
+    }.bind(this));
   }
 
 });

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
+    "ember-data": "1.0.0-beta.19.2",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.8",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
+    "ember-data": "1.0.0-beta.19.2",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5"


### PR DESCRIPTION
Fix for https://github.com/lolmaus/ember-cli-stained-by-children/issues/11

I verified that this fixes the tests for beta 19.2 (and that they are broken without it)
